### PR TITLE
fix: a typo on variable `learing_rate ` -> `learning_rate `

### DIFF
--- a/scannet/train.py
+++ b/scannet/train.py
@@ -82,7 +82,7 @@ def get_learning_rate(batch):
                         DECAY_STEP,          # Decay step.
                         DECAY_RATE,          # Decay rate.
                         staircase=True)
-    learing_rate = tf.maximum(learning_rate, 0.00001) # CLIP THE LEARNING RATE!
+    learning_rate = tf.maximum(learning_rate, 0.00001) # CLIP THE LEARNING RATE!
     return learning_rate        
 
 def get_bn_decay(batch):


### PR DESCRIPTION
The returned `learning_rate` has not been clipped